### PR TITLE
Ignore pebble start failure for scripts

### DIFF
--- a/dockers/docker-orchagent/rockcraft.yaml
+++ b/dockers/docker-orchagent/rockcraft.yaml
@@ -70,15 +70,6 @@ services:
       DEBIAN_FRONTEND: "noninteractive"
       IMAGENAME: "docker-orchagent"
       DISTRO: "noble"
-  restore_neighbors:
-    # Don't restart .py even if it fails
-    command: /usr/bin/restore_neighbors.py
-    override: replace
-    on-success: ignore
-    environment:
-      DEBIAN_FRONTEND: "noninteractive"
-      IMAGENAME: "docker-orchagent"
-      DISTRO: "noble"
   enable_counters:
     # Don't restart .py even if it fails
     command: /usr/bin/enable_counters.py

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -65,7 +65,8 @@ for file in $SWSSCONFIG_ARGS; do
     sleep 1
 done
 
-pebble start restore_neighbors
+/usr/bin/restore_neighbors.py
+
 pebble start enable_counters
 
 SWITCH_TYPE=${SWITCH_TYPE:-`sonic-db-cli -s CONFIG_DB HGET 'DEVICE_METADATA|localhost' 'switch_type'`}


### PR DESCRIPTION
The `pebble start` command fails (with non-zero exit code) if the service exit within 1s, regardless of the service's exit code, or the `on-success/failure` field in the yaml.

That should be avoided, by turning that service it into a normal command in initialize script. 